### PR TITLE
fix: enable gpui runtime_shaders feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "GPU-rendered, keyboard-driven agent tiling manager"
 license = "MIT"
 
 [dependencies]
-gpui = "0.2"
+gpui = { version = "0.2", features = ["runtime_shaders"] }
 async-channel = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary
  Enables the `runtime_shaders` feature for the `gpui` dependency to fix GPUI shader handling.

## Change
  - **Cargo.toml:** `gpui = "0.2"` → `gpui = { version = "0.2", features = ["runtime_shaders"] }`

## Why
  The `runtime_shaders` feature is required for correct shader behavior in this setup. Without it, open-squirrel would not compile on my system.